### PR TITLE
ideas about how to make business-friendly language extensions

### DIFF
--- a/samples/instruments/butterfly.trade
+++ b/samples/instruments/butterfly.trade
@@ -60,3 +60,4 @@ contractual definitions: ISDA2000
   
 -- Notes:
 -- lexems: is, strike, number of options, option entittlement, premium, exchange, expire at, settle in, obtain price from, adjust by, if index was etc.
+0

--- a/samples/instruments/option.template
+++ b/samples/instruments/option.template
@@ -1,20 +1,27 @@
 -- this file contains templates for instrument's fields and actions definitions 
--- may be used to generate (in compile time) subparsers based on very simplified template-like grammar
--- grammars may be concatenated with each other when constructing new type, like traits: Expiring Option is Option is Expiring - parser will try to match lines from every grammar
+-- may be used to generate (in compile time) subparsers based on very simplified business-readable grammar
+-- it will allow users to extent products or messages (like in fpml5 but much simpler) or create type-specific default values
+-- grammars may be concatenated with each other when constructing new type, like traits: Expiring Option is Option is Expiring - parser will try to match lines from every grammar. In fpml5 xsi:type was used for this purpose and allowed only one extension to be added(we can add more).
 -- every element and line is non-mandatory and repeatable by default
--- also highlighting files could be generated using this template
+-- if substitution has default value {count: Count} it will be used if line/substitution not matched. when mixing grammars in new type - the left has higher priority (so actually is expressions must be linearized like traits in scala).
+-- default values may refer to other values in formulas: {premium: Money = count * optionsCount * 3000 CHF}
+-- you can make line mandatory by specifying "!" in the end of the line
+-- any word after {* : Count} may be matched as plural: with {count: Count} underlyer/with {count: Count} underlyers
+-- also, highlighting files could be generated using this template
 
 -- expected grammar for Option type
 instrument {name: String} is Option
 exercise at {exerciseDate: Date} {$automatic: String}
-  {optionsCount: Count} options with strike {strike: Money}
-  with {count: Count} underlyer
+  {optionsCount: Count} options with strike {strike: Money}!
+  with {count: Count = one} underlyer
   pay premium {premium: Money} from {partyFrom: Party} to {partyTo: Party} at {premiumDate: Date}
   
 -- expected grammar for Expiring type  
-instrument {name: String} is Expiring Option
-  expire at {e: Enum{OSP, Open, Close}}
+instrument {name: String} is Expiring
+  expire at {e: Enum{OSP, Open, Close} = OSP}
+  with count {count: Count = two} underlyer
   
 -- expected grammar for Swap type
 instrument {name: String} is Swap
   stream {period: Period} with notional {notional: NotionalParser}
+  


### PR DESCRIPTION
FpMl (from version 5) allows users to extent it (instead of composing inside other formats like *pMl) using inheritance but it still pretty much painful and restricted. we can do better :).
